### PR TITLE
Add custom threading module and tests

### DIFF
--- a/src/wazuh_qa_framework/generic_modules/threading/thread.py
+++ b/src/wazuh_qa_framework/generic_modules/threading/thread.py
@@ -1,0 +1,72 @@
+"""
+Custom threading module for wrapping threading.Thread module and allowing to raise the thread exception to the parent
+process.
+
+Classes
+-------
+
+- Thread(threading.Thread):
+    - run
+    - start
+    - join
+"""
+
+import threading
+
+
+class Thread(threading.Thread):
+    """Class which allows us to upload the thread exception to the parent process.
+
+    Args:
+        target (callable): Function to run in the thread.
+        parameters (dict): Function parameters. Used as kwargs in the callable function.
+        throw_exception (boolean): Flag to active/deactivate the exception raising from the thread.
+
+    Attributes:
+        target (callable): Function to run in the thread.
+        parameters (dict): Function parameters. Used as kwargs in the callable function.
+        exception (Exception): Thread exception in case it has occurred.
+        throw_exception (boolean): Flag to active/deactivate the exception raising from the thread.
+    """
+    def __init__(self, target, parameters=None, throw_exception=True):
+        super().__init__()
+        self.target = target
+        self.exception = None
+        self.parameters = {} if parameters is None else parameters
+        self.throw_exception = throw_exception
+        self._return = None
+
+    def _run(self):
+        """Run the target function with its parameters in the thread"""
+        self._return = self.target(**self.parameters)
+
+    def run(self):
+        """Overwrite run function of threading Thread module.
+
+        Launch the target function and catch the exception in case it occurs.
+        """
+        try:
+            self._run()
+        except Exception as exception:
+            self.exception = exception
+
+    def start(self):
+        """Overwrite run function of threading Thread module.
+
+        Launch the target function and catch the exception in case it occurs.
+        """
+        super().start()
+
+    def join(self):
+        """Overwrite join function of threading Thread module.
+
+        Raises the exception to the parent in case it was raised when executing the target function.
+
+        Raises:
+            Exception: Target function exception if ocurrs
+        """
+        super().join()
+        if self.exception and self.throw_exception:
+            raise self.exception
+
+        return self._return

--- a/tests/generic_modules/test_threading.py
+++ b/tests/generic_modules/test_threading.py
@@ -1,0 +1,41 @@
+"""
+Module to test the custom Thead class from the wazuh-qa-framework
+"""
+import pytest
+import time
+
+from wazuh_qa_framework.generic_modules.threading.thread import Thread
+
+
+def test_target_runner():
+    """Check that the thread target function is run."""
+    def default_function(param_1, param_2):
+        """Sample function"""
+        time.sleep(1)
+        return param_1 + param_2
+
+    # Create and start the thread calling the function with parameters
+    thread = Thread(target=default_function, parameters={'param_1': 1, 'param_2': 2})
+    thread.start()
+
+    # Wait until the thread tasks has finished and get the result
+    returned_value = thread.join()
+
+    # Check that the thread tasks has been completed and check the result
+    assert returned_value == 3
+
+
+def test_raise_exception():
+    """Check that the thread exception is propagated to the parent process"""
+    def raise_exception():
+        """Sample function that raises an exception"""
+        raise RuntimeError('This is a triggered exception')
+
+    # Create and start the thread calling the exception function
+    thread = Thread(target=raise_exception)
+    thread.start()
+
+    # Check that the thread exception has been propagated to the parent process
+    with pytest.raises(RuntimeError):
+        thread.join()
+        assert False, 'The thread exception has not been propagated to the parent process'


### PR DESCRIPTION
| Related issue |
|----------------------|
| #8      |


This PR adds a new module to manage custom threads.

The motivation of this new "wrapper" class is that when an exception occurs in a thread in Python, this exception is not automatically propagated to the parent process, since threads share the same memory space and the exception may occur in a different context than the parent process. Instead, you must catch the exception within the thread and communicate it to the parent process somehow.

This new class allows us to get the thread exception and raise it to the parent process when doing the `join`. In addition, I have added two unit tests to check that it works properly.